### PR TITLE
메뉴와 액티비티 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
         <activity android:name=".ui.join.JoinActivity"
             android:exported="true"
             android:screenOrientation="portrait"/>
+        <activity android:name=".ui.joinSuccess.JoinSuccessActivity"
+            android:exported="true"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,8 +18,8 @@
             android:name=".ui.join.JoinActivity"
             android:exported="true"
             android:screenOrientation="portrait" />
-            android:screenOrientation="portrait"/>
-        <activity android:name=".ui.joinSuccess.JoinSuccessActivity"
+        <activity
+            android:name=".ui.joinSuccess.JoinSuccessActivity"
             android:exported="true"
             android:screenOrientation="portrait"/>
         <activity

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/join/JoinActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/join/JoinActivity.kt
@@ -1,12 +1,24 @@
 package com.sookmyung.hanmundan.ui.join
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.sookmyung.hanmundan.R
+import com.sookmyung.hanmundan.databinding.ActivityJoinBinding
+import com.sookmyung.hanmundan.ui.joinSuccess.JoinSuccessActivity
 
 class JoinActivity : AppCompatActivity() {
+    val binding: ActivityJoinBinding by lazy {
+        ActivityJoinBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_join)
+        setContentView(binding.root)
+
+        binding.ibJoinNameCheck.setOnClickListener {
+            val intentToSuccess = Intent(this, JoinSuccessActivity::class.java)
+            startActivity(intentToSuccess)
+            finish()
+        }
     }
 }

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/joinSuccess/JoinSuccessActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/joinSuccess/JoinSuccessActivity.kt
@@ -15,8 +15,6 @@ class JoinSuccessActivity : AppCompatActivity() {
         setContentView(R.layout.activity_join_success)
 
         Handler(Looper.getMainLooper()).postDelayed({
-
-            // 일정 시간이 지나면 MainActivity로 이동
             val intentToMain = Intent(this, MainActivity::class.java)
             startActivity(intentToMain)
             finish()

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/joinSuccess/JoinSuccessActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/joinSuccess/JoinSuccessActivity.kt
@@ -1,0 +1,25 @@
+package com.sookmyung.hanmundan.ui.joinSuccess
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import com.sookmyung.hanmundan.R
+import com.sookmyung.hanmundan.ui.main.MainActivity
+
+
+class JoinSuccessActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_join_success)
+
+        Handler(Looper.getMainLooper()).postDelayed({
+
+            // 일정 시간이 지나면 MainActivity로 이동
+            val intentToMain = Intent(this, MainActivity::class.java)
+            startActivity(intentToMain)
+            finish()
+        }, 1000)
+    }
+}

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
@@ -11,6 +11,7 @@ import com.google.android.material.navigation.NavigationView
 import com.sookmyung.hanmundan.R
 import com.sookmyung.hanmundan.databinding.ActivityMainBinding
 import com.sookmyung.hanmundan.ui.calender.CalenderActivity
+import com.sookmyung.hanmundan.ui.myPage.MyPageActivity
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
     val binding: ActivityMainBinding by lazy {
@@ -26,11 +27,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         var bookmarkState = false
 
         binding.ivMainBlankedBookmark.setOnClickListener {
-            if (bookmarkState == false) {
+            if (!bookmarkState) {
                 binding.ivMainBlankedBookmark.setImageResource(R.drawable.ic_bookmark_fill)
                 bookmarkState = true
-            }
-            else {
+            } else {
                 binding.ivMainBlankedBookmark.setImageResource(R.drawable.ic_bookmark_blank)
                 bookmarkState = false
             }
@@ -66,7 +66,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
 
             R.id.menu_item_my_page -> {
-                return true
+                val intentToMyPage = Intent(this, MyPageActivity::class.java)
+                startActivity(intentToMyPage)
+                binding.dlMain.closeDrawers()
             }
         }
         return false

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
@@ -23,6 +23,18 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         val headerNavigation = binding.nvMainMenu.getHeaderView(0)
         val btnMenuClose = headerNavigation.findViewById<ImageView>(R.id.iv_navigation_navi)
         val navigationView = binding.nvMainMenu
+        var bookmarkState = false
+
+        binding.ivMainBlankedBookmark.setOnClickListener {
+            if (bookmarkState == false) {
+                binding.ivMainBlankedBookmark.setImageResource(R.drawable.ic_bookmark_fill)
+                bookmarkState = true
+            }
+            else {
+                binding.ivMainBlankedBookmark.setImageResource(R.drawable.ic_bookmark_blank)
+                bookmarkState = false
+            }
+        }
 
         navigationView.setNavigationItemSelectedListener(this)
 

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
@@ -1,15 +1,18 @@
 package com.sookmyung.hanmundan.ui.main
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
+import com.google.android.material.navigation.NavigationView
 import com.sookmyung.hanmundan.R
 import com.sookmyung.hanmundan.databinding.ActivityMainBinding
+import com.sookmyung.hanmundan.ui.calender.CalenderActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
     val binding: ActivityMainBinding by lazy {
         ActivityMainBinding.inflate(layoutInflater)
     }
@@ -17,8 +20,11 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        val headerNavigation = binding.nvMenu.getHeaderView(0)
+        val headerNavigation = binding.nvMainMenu.getHeaderView(0)
         val btnMenuClose = headerNavigation.findViewById<ImageView>(R.id.iv_navigation_navi)
+        val navigationView = binding.nvMainMenu
+
+        navigationView.setNavigationItemSelectedListener(this)
 
         binding.ivMainNavi.setOnClickListener {
             binding.dlMain.openDrawer(GravityCompat.END)
@@ -31,14 +37,16 @@ class MainActivity : AppCompatActivity() {
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    override fun onNavigationItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.menu_item_main -> {
-                return true
+                binding.dlMain.closeDrawers()
             }
 
             R.id.menu_item_calendar -> {
-                return true
+                val intentToCalender = Intent(this, CalenderActivity::class.java)
+                startActivity(intentToCalender)
+                binding.dlMain.closeDrawers()
             }
 
             R.id.menu_item_bookmark -> {
@@ -49,7 +57,7 @@ class MainActivity : AppCompatActivity() {
                 return true
             }
         }
-        return super.onOptionsItemSelected(item)
+        return false
     }
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {

--- a/app/src/main/res/drawable/ic_bookmark_blank.xml
+++ b/app/src/main/res/drawable/ic_bookmark_blank.xml
@@ -6,6 +6,6 @@
   <path
       android:strokeWidth="1"
       android:pathData="M7.362,7.302V7.301C7.362,6.16 8.275,5.241 9.41,5.241H22.21C23.348,5.241 24.27,6.163 24.27,7.301V27.023L16.007,23.482L15.81,23.397L15.613,23.482L7.35,27.023L7.362,7.302Z"
-      android:fillColor="#ffffff"
-      android:strokeColor="#899878"/>
+      android:fillColor="@color/hmd_beige"
+      android:strokeColor="@color/hmd_green"/>
 </vector>

--- a/app/src/main/res/layout/activity_join.xml
+++ b/app/src/main/res/layout/activity_join.xml
@@ -49,6 +49,7 @@
         app:layout_constraintTop_toBottomOf="@id/tv_join_name_subtitle" />
 
     <ImageButton
+        android:id="@+id/ib_join_name_check"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="31dp"

--- a/app/src/main/res/layout/activity_join_success.xml
+++ b/app/src/main/res/layout/activity_join_success.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/hmd_green">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/iv_join_success_image"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
+            android:src="@drawable/ic_feather" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:fontFamily="@font/eulyoo1945_regular"
+            android:gravity="center"
+            android:textColor="@color/hmd_beige"
+            android:textSize="40sp"
+            tools:text="민주 님,\n당신이 되었네요!" />
+
+    </LinearLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -138,7 +138,7 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.navigation.NavigationView
-        android:id="@+id/nv_menu"
+        android:id="@+id/nv_main_menu"
         android:layout_width="250dp"
         android:layout_height="match_parent"
         android:layout_gravity="end"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dl_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/hmd_beige">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -118,7 +119,7 @@
             android:padding="15dp"
             android:textColor="@color/hmd_dark_green"
             android:textColorHint="@color/hmd_gray"
-            android:textSize="10sp"
+            android:textSize="11sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/ll_main_more_meaning" />


### PR DESCRIPTION
## Related Issue📮
- closed #12 
  
## Description
- 메인, 달력, 메인 페이지랑 메뉴 (메인에 있는 거) 연결
- 회원가입 페이지에서 확인 버튼 (깃털) 누르면 로고 페이지 2초 정도 뜨고 메인 페이지로 이동
- 메인 페이지에서 책갈피 누르면 꺼지거나 켜지게

## ScreenShot 📸
- 
![image](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/31c2a644-f112-44ab-947b-f36187a0eab4)
![image](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/97eb4ec9-1de3-4cb0-a4f1-16c4fed92b00)
![image](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/519556af-087d-4478-9b55-07936546b236)
![image](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/d1f52c82-1285-4f0c-9611-13003e8ce6a9)


## To Reviewers ✍🏻
- 로고 페이지는 tools로 넣어서 디자인 화면도 캡처했습니다...