### PR TITLE
달력에서 퇴고하기로 데이터 받기, 퇴고하기 글 수정, 삭제

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,11 +19,6 @@
             android:name=".ui.join.JoinActivity"
             android:exported="true"
             android:screenOrientation="portrait">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ui.joinSuccess.JoinSuccessActivity"

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/main/MainActivity.kt
@@ -59,7 +59,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     var lastWriting: String? = null
     var currentWriting: String? = null
     private var moreMeaningState = false
-    private var bookmarkState = false
 
     private lateinit var databaseReal: DatabaseReference
     private val dateInPhone = getCurrentDate()
@@ -67,7 +66,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     private lateinit var todayDocumentId: String
     private lateinit var todayWord: String
     private var todayWordSentence: String? = null
-    private var todayWordBookmarkState: Boolean = false
+    private var todayBookmarkState = false
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -109,14 +108,16 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         try {
             val databaseReference = databaseReal.child("hanmundan")
             val dataSnapshot = databaseReference.get().await()
+
             for (childSnapshot in dataSnapshot.children) {
                 dateInDatabase = childSnapshot.child("date").getValue(String::class.java).toString()
+
                 if (dateInDatabase == dateInPhone) {
                     todayDocumentId = childSnapshot.key!!
                     todayWord = childSnapshot.child("word").getValue(String::class.java)!!
                     todayWordSentence =
                         childSnapshot.child("sentence").getValue(String::class.java) ?: ""
-                    bookmarkState =
+                    todayBookmarkState =
                         childSnapshot.child("bookmark").getValue(Boolean::class.java) ?: false
                     break
                 }
@@ -149,7 +150,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     private fun initUI() {
         binding.tvMainWordTitle.text = todayWord
         binding.etMainWriting.text = Editable.Factory.getInstance().newEditable(todayWordSentence)
-        bookmarkState = todayWordBookmarkState
+        //bookmarkState = todayWordBookmarkState
     }
 
     private fun retrofitWork() {
@@ -225,8 +226,8 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     private fun clickBookmarkButton() {
         binding.ivMainBlankedBookmark.setOnClickListener {
-            bookmarkState = !bookmarkState
-            if (bookmarkState) {
+            todayBookmarkState = !todayBookmarkState
+            if (todayBookmarkState) {
                 binding.ivMainBlankedBookmark.setImageResource(R.drawable.ic_bookmark_fill)
                 SnackbarCustom.make(binding.root, "책갈피를 끼웠습니다.").show()
             } else {
@@ -238,7 +239,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                     todayWord,
                     todayWordSentence ?: "",
                     dateInDatabase,
-                    bookmarkState
+                    todayBookmarkState
                 )
             )
         }
@@ -255,7 +256,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                         todayWord,
                         binding.etMainWriting.text.toString(),
                         dateInDatabase,
-                        bookmarkState
+                        todayBookmarkState
                     )
                 )
             }

--- a/app/src/main/java/com/sookmyung/hanmundan/ui/rewrite/RewriteActivity.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/ui/rewrite/RewriteActivity.kt
@@ -3,39 +3,115 @@ package com.sookmyung.hanmundan.ui.rewrite
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.view.View
 import android.view.Window
-import android.widget.ImageView
 import android.widget.TextView
+import com.google.android.gms.tasks.Task
 import com.google.android.material.textview.MaterialTextView
+import com.google.firebase.Firebase
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.database
 import com.sookmyung.hanmundan.R
 import com.sookmyung.hanmundan.data.RetrofitInstance
 import com.sookmyung.hanmundan.databinding.ActivityRewriteBinding
+import com.sookmyung.hanmundan.model.DailyRecord
 import com.sookmyung.hanmundan.model.DictionaryResponseDTO
 import com.sookmyung.hanmundan.model.Item
+import com.sookmyung.hanmundan.util.SnackbarCustom
 import com.sookmyung.hanmundan.util.binding.BindingActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class RewriteActivity : BindingActivity<ActivityRewriteBinding>(R.layout.activity_rewrite) {
     private lateinit var deletedialog: Dialog
     private var moreMeaningState = false
+    var saveWritingState = false
+    var lastWriting: String? = null
+    var currentWriting: String? = null
+
+    private lateinit var databaseReal: DatabaseReference
+    private lateinit var currentDocumentId: String
+    private lateinit var currentWord: String
+    private lateinit var currentDate: String
+    private var currentWordSentence: String? = null
+    private var currentWordBookmarkState = false
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        databaseReal =
+            Firebase.database("https://hanmundan-default-rtdb.asia-southeast1.firebasedatabase.app/").reference
+
+        getIntentFromCalender()
+        coroutineScope.launch {
+            initWord()
+            initClick()
+        }
+
+        initUI()
         deletedialog = Dialog(this)
         deletedialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
         deletedialog.setContentView(R.layout.dialog_delete_sentence)
-        findViewById<ImageView>(R.id.iv_rewrite_delete).setOnClickListener { showDialog() }
         clickMoreMeaningButton()
         retrofitWork()
+    }
+
+    private fun getIntentFromCalender() {
+        val intentFromCalender = intent
+        currentWord = intentFromCalender.getStringExtra("word").toString()
+        currentWordSentence = intentFromCalender.getStringExtra("sentence")
+        currentDate = intentFromCalender.getStringExtra("date").toString()
+        currentWordBookmarkState = intentFromCalender.getBooleanExtra("bookmark", false)
+    }
+
+    private suspend fun initWord() {
+        try {
+            val databaseReference = databaseReal.child("hanmundan")
+            val dataSnapshot = databaseReference.get().await()
+            for (childSnapshot in dataSnapshot.children) {
+                val dateInDatabase =
+                    childSnapshot.child("date").getValue(String::class.java).toString()
+                if (dateInDatabase == currentDate) {
+                    currentDocumentId = childSnapshot.key!!
+                    break
+                }
+            }
+        } catch (exception: Exception) {
+            Log.d("hmm", "Error getting data: ", exception)
+        }
+    }
+
+    private suspend fun <T> Task<T>.await(): T {
+        return suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result ->
+                continuation.resume(result)
+            }
+            addOnFailureListener { exception ->
+                continuation.resumeWithException(exception)
+            }
+        }
+    }
+
+    private fun initUI() {
+        binding.tvRewriteWordTitle.text = currentWord
+        binding.etRewriteWriting.text =
+            Editable.Factory.getInstance().newEditable(currentWordSentence)
     }
 
     private fun retrofitWork() {
         val service = RetrofitInstance.retrofitService
 
-        service.getDictionary(RetrofitInstance.CLIENT_SECRET, "역사", "json")
+        service.getDictionary(RetrofitInstance.CLIENT_SECRET, currentWord, "json")
             .enqueue(object : Callback<DictionaryResponseDTO> {
                 override fun onResponse(
                     call: Call<DictionaryResponseDTO>,
@@ -70,13 +146,10 @@ class RewriteActivity : BindingActivity<ActivityRewriteBinding>(R.layout.activit
         }
     }
 
-    private fun showDialog() {
-        deletedialog.setCancelable(false)
-        deletedialog.show()
-        deletedialog.findViewById<MaterialTextView>(R.id.tv_dialog_no)
-            .setOnClickListener { deletedialog.dismiss() }
-        deletedialog.findViewById<MaterialTextView>(R.id.tv_dialog_yes)
-            .setOnClickListener { finish() }
+    private fun initClick() {
+        clickMoreMeaningButton()
+        clickSaveButton()
+        clickDeleteButton()
     }
 
     private fun clickMoreMeaningButton() {
@@ -89,5 +162,92 @@ class RewriteActivity : BindingActivity<ActivityRewriteBinding>(R.layout.activit
 
     private fun setMeaningVisibility(view: View, isVisible: Boolean) {
         view.visibility = if (isVisible) View.VISIBLE else View.GONE
+    }
+
+    private fun clickSaveButton() {
+        binding.btnRewriteSaveWriting.setOnClickListener {
+            updateWritingValue()
+            updateSaveWritingState()
+
+            if (saveWritingState) {
+                SnackbarCustom.make(binding.root, "저장되었습니다.").show()
+                setDocument(
+                    DailyRecord(
+                        currentWord,
+                        binding.etRewriteWriting.text.toString(),
+                        currentDate,
+                        currentWordBookmarkState
+                    )
+                )
+            }
+        }
+    }
+
+    private fun setDocument(data: DailyRecord) {
+        databaseReal.child("hanmundan").child(currentDocumentId).setValue(data)
+            .addOnSuccessListener {
+                Log.e("hmm", "setDocument success")
+            }
+            .addOnFailureListener {
+                Log.e("hmm", "setDocument fail")
+            }
+    }
+
+    private fun updateWritingValue() {
+        if (lastWriting == null) {
+            lastWriting = binding.etRewriteWriting.text.toString()
+            currentWriting = lastWriting
+        } else {
+            lastWriting = currentWriting
+            currentWriting = binding.etRewriteWriting.text.toString()
+        }
+    }
+
+    private fun updateSaveWritingState() {
+        binding.etRewriteWriting.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+                updateWritingValue()
+                saveWritingState = lastWriting == currentWriting
+            }
+
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+                updateWritingValue()
+                saveWritingState = lastWriting == currentWriting
+            }
+
+            override fun afterTextChanged(s: Editable) {
+                updateWritingValue()
+                saveWritingState = lastWriting == currentWriting
+            }
+        })
+    }
+
+    private fun clickDeleteButton() {
+        binding.ivRewriteDelete.setOnClickListener {
+            showDialog()
+        }
+    }
+
+    private fun showDialog() {
+        deletedialog.setCancelable(false)
+        deletedialog.show()
+        deletedialog.findViewById<MaterialTextView>(R.id.tv_dialog_no)
+            .setOnClickListener { deletedialog.dismiss() }
+        deletedialog.findViewById<MaterialTextView>(R.id.tv_dialog_yes)
+            .setOnClickListener { doDelete() }
+    }
+
+    private fun doDelete() {
+        binding.etRewriteWriting.text = Editable.Factory.getInstance().newEditable("")
+        currentWordBookmarkState = false
+        setDocument(
+            DailyRecord(
+                currentWord,
+                binding.etRewriteWriting.text.toString(),
+                currentDate,
+                currentWordBookmarkState
+            )
+        )
+        finish()
     }
 }

--- a/app/src/main/java/com/sookmyung/hanmundan/util/SnackbarCustom.kt
+++ b/app/src/main/java/com/sookmyung/hanmundan/util/SnackbarCustom.kt
@@ -13,7 +13,7 @@ class SnackbarCustom(view: View, private val message: String) {
     }
 
     private val context = view.context
-    private val snackBar = Snackbar.make(view, "", 5000)
+    private val snackBar = Snackbar.make(view, "", 2000)
     private val snackBarView =
         LayoutInflater.from(context).inflate(R.layout.snackbar_layout, null, false)
     private val snackBarLayout = snackBar.view as Snackbar.SnackbarLayout

--- a/app/src/main/res/layout/activity_rewrite.xml
+++ b/app/src/main/res/layout/activity_rewrite.xml
@@ -147,7 +147,7 @@
         </LinearLayout>
 
         <EditText
-            android:id="@+id/cl_main_word_meaning"
+            android:id="@+id/et_rewrite_writing"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginHorizontal="50dp"


### PR DESCRIPTION
## Related Issue📮
- closed #45 
  
## Description
- 달력 -> 퇴고 데이터 받기
- 퇴고하기에서 글 수정, 삭제

## ScreenShot 📸
- 
![Screenshot_20231218-190829_hanmundan](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/68aa31ee-0ff5-4d73-accf-8fb591752f8e)
![Screenshot_20231218-190753_hanmundan](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/2ec27b31-05e9-460d-9f3c-bf05cae6fe47)
![Screenshot_20231218-190813_hanmundan](https://github.com/HAN-MUN-CHEOL/hanmundan-aos/assets/105511209/41af5311-b346-46e8-baf1-5ec45b7929b8)

## To Reviewers ✍🏻
- 사진엔 없지만 삭제하면 다이얼로그 뜹니도
